### PR TITLE
Bugfix/crash on morph relations

### DIFF
--- a/src/ModelReflector.php
+++ b/src/ModelReflector.php
@@ -97,12 +97,12 @@ class ModelReflector
 
         foreach ($reflectionMethods as $reflectionMethod) {
             if ($this->reflectionMethodIsRelation($reflectionMethod)) {
-                $methodName                    = $reflectionMethod->getName();
-                $relation                      = $modelInstance->{$methodName}();
-                $relatedModel                  = $relation->getRelated();
+                $methodName   = $reflectionMethod->getName();
+                $relation     = $modelInstance->{$methodName}();
+                $relatedModel = $relation->getRelated();
                 $relations->put($methodName, [
-                    'relation'                => $methodName,
-                    'returnType'              => $reflectionMethod->getReturnType()->getName(),
+                    'relation'   => $methodName,
+                    'returnType' => $reflectionMethod->getReturnType()->getName(),
                 ]);
 
                 // Not available for some polymorph relations.

--- a/src/ModelReflector.php
+++ b/src/ModelReflector.php
@@ -101,15 +101,18 @@ class ModelReflector
                 $relation     = $modelInstance->{$methodName}();
                 $relatedModel = $relation->getRelated();
 
+                $getForeignKeyNameMethodExists = method_exists($relation, 'getForeignKeyName');
+                $getQualifiedForeignKeyNameMethodExists = method_exists($relation, 'getQualifiedForeignKeyName');
+
                 $relations->put($methodName, [
                     'relation'                => $methodName,
                     'returnType'              => $reflectionMethod->getReturnType()->getName(),
                     'relatedClass'            => get_class($relatedModel),
                     'relatedModel'            => $relatedModel,
                     'relatedTable'            => $relatedModel->getTable(),
-                    'foreignKeyName'          => $relation->getForeignKeyName(),
-                    'qualifiedForeignKeyName' => $relation->getQualifiedForeignKeyName(),
-                    'isRelationParent'        => sprintf('%s.%s', $modelInstance->getTable(), $relation->getForeignKeyName()) !== $relation->getQualifiedForeignKeyName(),
+                    'foreignKeyName'          => $getForeignKeyNameMethodExists ? $relation->getForeignKeyName() : null,
+                    'qualifiedForeignKeyName' => $getQualifiedForeignKeyNameMethodExists ? $relation->getQualifiedForeignKeyName() : null,
+                    'isRelationParent'        => $getForeignKeyNameMethodExists && $getQualifiedForeignKeyNameMethodExists ? sprintf('%s.%s', $modelInstance->getTable(), $relation->getForeignKeyName()) !== $relation->getQualifiedForeignKeyName() : null,
                 ]);
             }
         }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added conditional checks to prevent crashes when dealing with polymorph relations in higher Laravel 9 versions.
- Refactored the code to provide less information about polymorph relations, ensuring compatibility and stability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModelReflector.php</strong><dd><code>Fix crash and enhance handling of polymorph relations</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/ModelReflector.php

<li>Added conditional checks for polymorph relations.<br> <li> Prevented crash by handling methods that may not exist.<br> <li> Refactored code to provide less information for certain relations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cybex-gmbh/laravel-reflector/pull/12/files#diff-face89c2dc57e01fac4eb6fe94a18b30b42ea36ab196b24dfe0c835097de5c53">+16/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

